### PR TITLE
Change how dayWeekText is created

### DIFF
--- a/Example/MJCalendar/ViewController.swift
+++ b/Example/MJCalendar/ViewController.swift
@@ -86,6 +86,9 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         // Set start day. Available type: .Monday, Sunday
         self.calendarView.configuration.startDayType = .Monday
 
+        // Set number of letters presented in the week days label
+        self.calendarView.configuration.lettersInWeekDayLabel = .One
+
         // Set day text font
         self.calendarView.configuration.dayTextFont = UIFont.systemFontOfSize(12)
 

--- a/Pod/Classes/MJConfiguration.swift
+++ b/Pod/Classes/MJConfiguration.swift
@@ -28,11 +28,19 @@ public struct MJConfiguration {
     public enum StartDayType {
         case Monday, Sunday
     }
-    
+
+    public enum LettersInWeekDay: Int {
+        case One = 1
+        case Two
+        case Three
+    }
+
     public enum SelectedDayType {
         case Filled, Border
     }
-    
+
+    public var lettersInWeekDayLabel:LettersInWeekDay = .Three
+
     public var periodType: PeriodType = .Month
     public var dayViewType: DayViewType = .Circle
     public var startDayType: StartDayType = .Monday

--- a/Pod/Classes/MJWeekLabelsView.swift
+++ b/Pod/Classes/MJWeekLabelsView.swift
@@ -10,28 +10,26 @@ import UIKit
 
 class MJWeekLabelsView: MJComponentView {
     var weekLabels: [UILabel] = []
-    var dayWeekText: [String] {
-        if self.delegate.configurationWithComponent(self).startDayType == .Monday {
-            return [
-                "MON",
-                "TUE",
-                "WED",
-                "THU",
-                "FRI",
-                "SAT",
-                "SUN"
-            ]
-        } else {
-            return [
-                "SUN",
-                "MON",
-                "TUE",
-                "WED",
-                "THU",
-                "FRI",
-                "SAT"
-            ]
+
+    lazy var formatter = NSDateFormatter()
+    var dayWeekText:[String] {
+        var dayWeekText:[String] = []
+        var dayIndex: Int
+
+        for index in 1...7 {
+
+            switch self.delegate.configurationWithComponent(self).startDayType {
+            case .Monday:
+                dayIndex = index % 7
+            case .Sunday:
+                dayIndex = index - 1
+            }
+
+            let day : NSString = formatter.weekdaySymbols[dayIndex]
+            dayWeekText.append(day.substringToIndex(self.delegate.configurationWithComponent(self).lettersInWeekDayLabel.rawValue).uppercaseString)
         }
+
+        return dayWeekText
     }
 
     override init(delegate: MJComponentDelegate) {


### PR DESCRIPTION
Removed hard coded week day labels. Now you should be able to select one, two and/or three letter abbreviation for the week day name. Language depends on the current locale.
